### PR TITLE
Arhitecture solution moving dt os to shared layer

### DIFF
--- a/API-Layer/Controllers/ContentController.cs
+++ b/API-Layer/Controllers/ContentController.cs
@@ -1,9 +1,7 @@
 ﻿using Application_Layer.Commands.ContentCommands;
-using Application_Layer.Commands.ModuleCommands.CreateModule;
-using Application_Layer.DTO_s.Content;
-using Application_Layer.DTO_s.Module;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
+using Shared_Layer.DTO_s.Content;
 
 namespace API_Layer.Controllers
 {

--- a/API-Layer/Controllers/CourseController.cs
+++ b/API-Layer/Controllers/CourseController.cs
@@ -3,12 +3,12 @@ using Application_Layer.Commands.CourseCommands.CreateCourseHasModuleConnection;
 using Application_Layer.Commands.CourseCommands.DeleteCourse;
 using Application_Layer.Commands.CourseCommands.DeleteCourseHasModuleConnection;
 using Application_Layer.Commands.CourseCommands.UpdateCourse;
-using Application_Layer.DTO_s;
 using Application_Layer.Queries.CourseQueries.GetAllCoursesBySearchCriteria;
 using Application_Layer.Queries.CourseQueries.GetCourseById;
 using Domain_Layer.Models.Course;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
+using Shared_Layer.DTO_s.Course;
 
 namespace API_Layer.Controllers
 {

--- a/API-Layer/Controllers/ModuleController.cs
+++ b/API-Layer/Controllers/ModuleController.cs
@@ -1,11 +1,11 @@
 ﻿using Application_Layer.Commands.ModuleCommands.CreateModule;
 using Application_Layer.Commands.ModuleCommands.DeleteModule;
 using Application_Layer.Commands.ModuleCommands.UpdateModule;
-using Application_Layer.DTO_s.Module;
 using Application_Layer.Queries.ModuleQueries.GetAllModulesByCourse;
 using Application_Layer.Queries.ModuleQueries.GetModuleById;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
+using Shared_Layer.DTO_s.Module;
 
 namespace API_Layer.Controllers
 {

--- a/API-Layer/Controllers/UserController.cs
+++ b/API-Layer/Controllers/UserController.cs
@@ -2,7 +2,6 @@
 using Application_Layer.Commands.DeleteUser;
 using Application_Layer.Commands.RegisterNewUser;
 using Application_Layer.Commands.UpdateUser;
-using Application_Layer.DTO_s;
 using Application_Layer.Queries.GetAllUsers;
 using Application_Layer.Queries.GetUserByEmail;
 using Application_Layer.Queries.GetUserById;
@@ -10,6 +9,7 @@ using Application_Layer.Queries.LoginUser;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Shared_Layer.DTO_s.User;
 namespace Application_Layer.Controllers
 {
     [Route("api/[controller]")]

--- a/Application-Layer/Application-Layer.csproj
+++ b/Application-Layer/Application-Layer.csproj
@@ -29,6 +29,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Infrastructure-Layer\Infrastructure-Layer.csproj" />
+    <ProjectReference Include="..\Shared-Layer\Shared-Layer.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Application-Layer/AutoMapper/MappingProfiles.cs
+++ b/Application-Layer/AutoMapper/MappingProfiles.cs
@@ -1,13 +1,14 @@
-﻿using Application_Layer.DTO_s;
-using Application_Layer.DTO_s.Content;
-using Application_Layer.DTO_s.Module;
-using AutoMapper;
+﻿using AutoMapper;
 using Domain_Layer.Models.Content;
 using Domain_Layer.Models.Course;
 using Domain_Layer.Models.Module;
 using Domain_Layer.Models.User;
+using Shared_Layer.DTO_s.Content;
+using Shared_Layer.DTO_s.Course;
+using Shared_Layer.DTO_s.Module;
+using Shared_Layer.DTO_s.User;
 
-namespace Application_Layer.AutoMaper
+namespace Application_Layer.AutoMapper
 {
     public class MappingProfiles : Profile
     {

--- a/Application-Layer/Commands/ContentCommands/CreateContentCommand.cs
+++ b/Application-Layer/Commands/ContentCommands/CreateContentCommand.cs
@@ -1,6 +1,7 @@
-﻿using Application_Layer.DTO_s.Content;
-using Domain_Layer.CommandOperationResult;
+﻿using Domain_Layer.CommandOperationResult;
 using MediatR;
+using Shared_Layer.DTO_s.Content;
+
 
 namespace Application_Layer.Commands.ContentCommands
 {

--- a/Application-Layer/Commands/CourseCommands/CreateCourse/CreateCourseCommand.cs
+++ b/Application-Layer/Commands/CourseCommands/CreateCourse/CreateCourseCommand.cs
@@ -1,7 +1,6 @@
 ﻿using Application_Layer.Commands.CourseCommands.CreateCourse;
-using Application_Layer.DTO_s;
 using MediatR;
-using Microsoft.AspNetCore.Mvc;
+using Shared_Layer.DTO_s.Course;
 
 namespace Application_Layer.Commands.CourseCommands
 {

--- a/Application-Layer/Commands/CourseCommands/CreateCourse/CreateCourseCommandValidator.cs
+++ b/Application-Layer/Commands/CourseCommands/CreateCourse/CreateCourseCommandValidator.cs
@@ -1,5 +1,4 @@
-﻿using Application_Layer.DTO_s;
-using FluentValidation;
+﻿using FluentValidation;
 
 namespace Application_Layer.Commands.CourseCommands.CreateCourse
 {

--- a/Application-Layer/Commands/CourseCommands/UpdateCourse/UpdateCourseCommand.cs
+++ b/Application-Layer/Commands/CourseCommands/UpdateCourse/UpdateCourseCommand.cs
@@ -1,6 +1,6 @@
-﻿using Application_Layer.DTO_s;
-using MediatR;
+﻿using MediatR;
 using Microsoft.AspNetCore.Mvc;
+using Shared_Layer.DTO_s.Course;
 
 namespace Application_Layer.Commands.CourseCommands.UpdateCourse
 {

--- a/Application-Layer/Commands/CourseCommands/UpdateCourse/UpdateCourseCommandValidator.cs
+++ b/Application-Layer/Commands/CourseCommands/UpdateCourse/UpdateCourseCommandValidator.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using FluentValidation;
+﻿using FluentValidation;
 
 namespace Application_Layer.Commands.CourseCommands.UpdateCourse
 {

--- a/Application-Layer/Commands/ModuleCommands/CreateModule/CreateModuleCommand.cs
+++ b/Application-Layer/Commands/ModuleCommands/CreateModule/CreateModuleCommand.cs
@@ -1,5 +1,5 @@
-﻿using Application_Layer.DTO_s.Module;
-using MediatR;
+﻿using MediatR;
+using Shared_Layer.DTO_s.Module;
 
 namespace Application_Layer.Commands.ModuleCommands.CreateModule
 {

--- a/Application-Layer/Commands/ModuleCommands/UpdateModule/UpdateModuleCommand.cs
+++ b/Application-Layer/Commands/ModuleCommands/UpdateModule/UpdateModuleCommand.cs
@@ -1,6 +1,6 @@
-﻿using Application_Layer.DTO_s.Module;
-using MediatR;
+﻿using MediatR;
 using Microsoft.AspNetCore.Mvc;
+using Shared_Layer.DTO_s.Module;
 
 namespace Application_Layer.Commands.ModuleCommands.UpdateModule
 {

--- a/Application-Layer/Commands/ModuleCommands/UpdateModule/UpdateModuleValidator.cs
+++ b/Application-Layer/Commands/ModuleCommands/UpdateModule/UpdateModuleValidator.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Application_Layer.DTO_s.Module;
-using Application_Layer.Validators.ValidationExtensions;
+﻿using Application_Layer.Validators.ValidationExtensions;
 using FluentValidation;
 
 namespace Application_Layer.Commands.ModuleCommands.UpdateModule

--- a/Application-Layer/Commands/UserCommands/RegisterNewUser/RegisterUserCommand.cs
+++ b/Application-Layer/Commands/UserCommands/RegisterNewUser/RegisterUserCommand.cs
@@ -1,6 +1,6 @@
-﻿using Application_Layer.DTO_s;
-using Domain_Layer.Models.User;
+﻿using Domain_Layer.Models.User;
 using MediatR;
+using Shared_Layer.DTO_s.User;
 
 namespace Application_Layer.Commands.RegisterNewUser
 {

--- a/Application-Layer/Commands/UserCommands/UpdateUser/UpdateUserCommand.cs
+++ b/Application-Layer/Commands/UserCommands/UpdateUser/UpdateUserCommand.cs
@@ -1,6 +1,6 @@
-﻿using Application_Layer.DTO_s;
-using Domain_Layer.Models.User;
+﻿using Domain_Layer.Models.User;
 using MediatR;
+using Shared_Layer.DTO_s.User;
 
 namespace Application_Layer.Commands.UpdateUser
 {

--- a/Application-Layer/DependencyInjection.cs
+++ b/Application-Layer/DependencyInjection.cs
@@ -1,9 +1,9 @@
-﻿using Application_Layer.AutoMaper;
-using Application_Layer.PipelineBehaviour;
+﻿using Application_Layer.PipelineBehaviour;
 using AutoMapper;
 using FluentValidation;
 using MediatR;
 using Microsoft.Extensions.DependencyInjection;
+using Application_Layer.AutoMapper;
 
 namespace Application_Layer
 {

--- a/Application-Layer/DependencyInjection.cs
+++ b/Application-Layer/DependencyInjection.cs
@@ -1,9 +1,9 @@
-﻿using Application_Layer.PipelineBehaviour;
+﻿using Application_Layer.AutoMapper;
+using Application_Layer.PipelineBehaviour;
 using AutoMapper;
 using FluentValidation;
 using MediatR;
 using Microsoft.Extensions.DependencyInjection;
-using Application_Layer.AutoMapper;
 
 namespace Application_Layer
 {

--- a/Application-Layer/Queries/UserQueries/LoginUser/LoginUserQuery.cs
+++ b/Application-Layer/Queries/UserQueries/LoginUser/LoginUserQuery.cs
@@ -1,5 +1,5 @@
-﻿using Application_Layer.DTO_s;
-using MediatR;
+﻿using MediatR;
+using Shared_Layer.DTO_s.User;
 
 namespace Application_Layer.Queries.LoginUser
 {

--- a/Shared-Layer/ApiServices/IUserServices.cs
+++ b/Shared-Layer/ApiServices/IUserServices.cs
@@ -1,5 +1,4 @@
-﻿
-using Domain_Layer.Models.User;
+﻿using Domain_Layer.Models.User;
 
 namespace Shared_Layer.ApiServices
 {

--- a/Shared-Layer/DTO´s/Content/CreateContentDTO.cs
+++ b/Shared-Layer/DTO´s/Content/CreateContentDTO.cs
@@ -1,5 +1,6 @@
 ﻿
-namespace Application_Layer.DTO_s.Content
+
+namespace Shared_Layer.DTO_s.Content
 {
     public class CreateContentDTO
     {

--- a/Shared-Layer/DTO´s/Course/CourseUpdateDTO.cs
+++ b/Shared-Layer/DTO´s/Course/CourseUpdateDTO.cs
@@ -1,5 +1,5 @@
 ﻿
-namespace Application_Layer.DTO_s
+namespace Shared_Layer.DTO_s.Course
 {
     public class CourseUpdateDTO
     {

--- a/Shared-Layer/DTO´s/Course/CreateCourseDTO.cs
+++ b/Shared-Layer/DTO´s/Course/CreateCourseDTO.cs
@@ -1,5 +1,5 @@
 ﻿
-namespace Application_Layer.DTO_s
+namespace Shared_Layer.DTO_s.Course
 {
     public class CreateCourseDTO
     {

--- a/Shared-Layer/DTO´s/Module/CreateModuleDTO.cs
+++ b/Shared-Layer/DTO´s/Module/CreateModuleDTO.cs
@@ -1,5 +1,5 @@
 ﻿
-namespace Application_Layer.DTO_s.Module
+namespace Shared_Layer.DTO_s.Module
 {
     public class CreateModuleDTO
     {

--- a/Shared-Layer/DTO´s/Module/UpdateModuleDTO.cs
+++ b/Shared-Layer/DTO´s/Module/UpdateModuleDTO.cs
@@ -1,5 +1,5 @@
 ﻿
-namespace Application_Layer.DTO_s.Module
+namespace Shared_Layer.DTO_s.Module
 {
     public class UpdateModuleDTO
     {

--- a/Shared-Layer/DTO´s/User/LoginUserDTO.cs
+++ b/Shared-Layer/DTO´s/User/LoginUserDTO.cs
@@ -1,6 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 
-namespace Application_Layer.DTO_s
+namespace Shared_Layer.DTO_s.User
 {
     public class LoginUserDTO
     {

--- a/Shared-Layer/DTO´s/User/RegisterUserDTO.cs
+++ b/Shared-Layer/DTO´s/User/RegisterUserDTO.cs
@@ -1,6 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 
-namespace Application_Layer.DTO_s
+namespace Shared_Layer.DTO_s.User
 {
     public class RegisterUserDTO
     {

--- a/Shared-Layer/DTO´s/User/UpdatingUserDTO.cs
+++ b/Shared-Layer/DTO´s/User/UpdatingUserDTO.cs
@@ -1,6 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 
-namespace Application_Layer.DTO_s
+namespace Shared_Layer.DTO_s.User
 {
     public class UpdatingUserDTO
     {

--- a/Test-Layer/ContentTest/IntegrationTest/ContentControllerIntegrationCreateContentTest.cs
+++ b/Test-Layer/ContentTest/IntegrationTest/ContentControllerIntegrationCreateContentTest.cs
@@ -1,10 +1,10 @@
 ﻿using API_Layer.Controllers;
 using Application_Layer.Commands.ContentCommands;
-using Application_Layer.DTO_s.Content;
 using Domain_Layer.CommandOperationResult;
 using FakeItEasy;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
+using Shared_Layer.DTO_s.Content;
 
 namespace Test_Layer.ContentTest.IntegrationTest
 {

--- a/Test-Layer/ContentTest/UnitTest/ContentCommandTest/CreateContentCommandHandlerTest.cs
+++ b/Test-Layer/ContentTest/UnitTest/ContentCommandTest/CreateContentCommandHandlerTest.cs
@@ -1,13 +1,9 @@
 ﻿using Application_Layer.Commands.ContentCommands;
-using Application_Layer.Commands.ModuleCommands.CreateModule;
-using Application_Layer.DTO_s.Content;
-using Application_Layer.DTO_s.Module;
 using AutoMapper;
 using Domain_Layer.Models.Content;
-using Domain_Layer.Models.Module;
 using FakeItEasy;
 using Infrastructure_Layer.Repositories.Content;
-
+using Shared_Layer.DTO_s.Content;
 
 namespace Test_Layer.ContentTest.UnitTest.ContentCommandTest
 {

--- a/Test-Layer/CourseTest/IntegrationTest/CourseControllerIntegrationCreateCourseTest.cs
+++ b/Test-Layer/CourseTest/IntegrationTest/CourseControllerIntegrationCreateCourseTest.cs
@@ -1,11 +1,10 @@
-﻿
-using API_Layer.Controllers;
+﻿using API_Layer.Controllers;
 using Application_Layer.Commands.CourseCommands;
 using Application_Layer.Commands.CourseCommands.CreateCourse;
-using Application_Layer.DTO_s;
 using FakeItEasy;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
+using Shared_Layer.DTO_s.Course;
 
 namespace Test_Layer.CourseTest.IntegrationTest
 {

--- a/Test-Layer/CourseTest/IntegrationTest/CourseControllerIntegrationGetCoursesBySearchCriteriaTest.cs
+++ b/Test-Layer/CourseTest/IntegrationTest/CourseControllerIntegrationGetCoursesBySearchCriteriaTest.cs
@@ -2,7 +2,6 @@
 using Application_Layer.Queries.CourseQueries.GetAllCoursesBySearchCriteria;
 using Domain_Layer.Models.Course;
 using FakeItEasy;
-using Infrastructure_Layer.Repositories.Course;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 

--- a/Test-Layer/CourseTest/IntegrationTest/CourseControllerIntegrationUpdateCourseTest.cs
+++ b/Test-Layer/CourseTest/IntegrationTest/CourseControllerIntegrationUpdateCourseTest.cs
@@ -1,15 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using API_Layer.Controllers;
+﻿using API_Layer.Controllers;
 using Application_Layer.Commands.CourseCommands.UpdateCourse;
-using Application_Layer.DTO_s;
 using Domain_Layer.Models.Course;
 using FakeItEasy;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
+using Shared_Layer.DTO_s.Course;
 
 namespace Test_Layer.CourseTest.IntegrationTest
 {

--- a/Test-Layer/CourseTest/UnitTest/CourseCommandTests/CreateCourseCommandHandlerTest.cs
+++ b/Test-Layer/CourseTest/UnitTest/CourseCommandTests/CreateCourseCommandHandlerTest.cs
@@ -1,9 +1,9 @@
 ﻿using Application_Layer.Commands.CourseCommands;
-using Application_Layer.DTO_s;
 using AutoMapper;
 using Domain_Layer.Models.Course;
 using FakeItEasy;
 using Infrastructure_Layer.Repositories.Course;
+using Shared_Layer.DTO_s.Course;
 
 namespace Test_Layer.CourseTest.UnitTest.CourseCommandTests
 {

--- a/Test-Layer/CourseTest/UnitTest/CourseCommandTests/DeleteCourseHasModuleConnectionTests.cs
+++ b/Test-Layer/CourseTest/UnitTest/CourseCommandTests/DeleteCourseHasModuleConnectionTests.cs
@@ -1,82 +1,11 @@
-﻿using System.Reflection.Metadata;
-using API_Layer.Controllers;
-using Application_Layer.Commands.CourseCommands.DeleteCourseHasModuleConnection;
+﻿using Application_Layer.Commands.CourseCommands.DeleteCourseHasModuleConnection;
 using FakeItEasy;
 using Infrastructure_Layer.Repositories.Course;
-using MediatR;
-using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
 
 namespace Test_Layer.CourseTest.UnitTest.CourseCommandTests
 {
     public class DeleteCourseHasModuleConnectionTests
     {
-        //private IMediator _mediator;
-        //private CourseController _controller;
-
-        //[SetUp]
-        //public void Setup()
-        //{
-        //    _mediator = A.Fake<IMediator>();
-        //    _controller = new CourseController(_mediator);
-
-        //}
-        //[Test]
-        //public async Task Handle_Successful_Deletion_ReturnsExpectedResult()
-        //{
-        //    // Arrange
-        //    var courseId = "valid-course-id";
-        //    var moduleId = "valid-module-id";
-        //    var expectedResult = new DeleteCourseHasModuleConnectionResult { Success = true, Message = "Connection is successfully deleted" };
-
-        //    var mockRepo = A.Fake<ICourseRepository>();
-        //    A.CallTo(() => mockRepo.DeleteCourseHasModuleConnection(courseId, moduleId)).Returns(Task.CompletedTask);
-
-        //    var handler = new DeleteCourseHasModuleConnectionCommandHandler(mockRepo);
-
-        //    // Act
-        //    var result = await handler.Handle(new DeleteCourseHasModuleConnectionCommand(courseId, moduleId), CancellationToken.None);
-
-        //    // Assert
-        //    Assert.True(result.Success);
-        //    Assert.That(result.Message, Is.EqualTo(expectedResult.Message));
-        //}
-
-
-        //[Test]
-        //public async Task DeleteCourse_ReturnsBadRequest_WhenInvalidInputProvided()
-        //{
-        //    //// Arrange
-        //    //var courseId = "";
-        //    //var moduleId = "existing-module-id";
-
-        //    //// Act
-        //    //var result = await _controller.DeleteCourseHasModuleConnection(courseId, moduleId);
-
-        //    //// Assert
-        //    //Assert.IsInstanceOf<BadRequestObjectResult>(result);
-        //    //var badRequestResult = result as BadRequestObjectResult;
-        //    //Assert.That(badRequestResult.Value, Is.EqualTo("CourseId or ModuleId cannot be empty"));
-        //}
-
-        //[Test]
-        //public async Task DeleteCourse_ReturnsInternalServerError_WhenExceptionOccursDuringDeletion()
-        //{
-        //    // Arrange
-        //    var courseId = "existing-course-id";
-        //    var moduleId = "existing-module-id";
-        //    var exceptionMessage = "An unexpected error occurred.";
-        //    A.CallTo(() => _mediator.Send(A<DeleteCourseHasModuleConnectionCommand>.That.Matches(c => c.CourseId == courseId && c.ModuleId == moduleId), default))
-        //   .Throws(new Exception(exceptionMessage));
-
-        //    // Act
-        //    var result = await _controller.DeleteCourseHasModuleConnection(courseId, moduleId);
-
-        //    // Assert
-        //    Assert.IsInstanceOf<StatusCodeResult>(result);
-        //    var statusResult = result as StatusCodeResult;
-        //    Assert.That(statusResult.StatusCode, Is.EqualTo(StatusCodes.Status500InternalServerError));
-        //}
         private DeleteCourseHasModuleConnectionCommandHandler _handler;
         private ICourseRepository _courseRepository;
 

--- a/Test-Layer/CourseTest/UnitTest/CourseCommandTests/UpdateCourseCommandHandlerTest.cs
+++ b/Test-Layer/CourseTest/UnitTest/CourseCommandTests/UpdateCourseCommandHandlerTest.cs
@@ -1,11 +1,11 @@
 ﻿using Application_Layer.Commands.CourseCommands.UpdateCourse;
-using Application_Layer.DTO_s;
 using AutoMapper;
 using Domain_Layer.Models.Course;
 using FakeItEasy;
 using FluentAssertions;
 using Infrastructure_Layer.Repositories.Course;
 using Microsoft.AspNetCore.Mvc;
+using Shared_Layer.DTO_s.Course;
 
 namespace Test_Layer.CourseTest.UnitTest.CourseCommandTests
 {

--- a/Test-Layer/CourseTest/UnitTest/CourseQueryTests/GetAllCoursesBySearchCriteriaQueryHandlarTests.cs
+++ b/Test-Layer/CourseTest/UnitTest/CourseQueryTests/GetAllCoursesBySearchCriteriaQueryHandlarTests.cs
@@ -9,7 +9,6 @@ namespace Test_Layer.CourseTest.UnitTest.CourseQueryTests
     [TestFixture]
     public class GetAllCoursesBySearchCriteriaQueryHandlarTests
     {
-
         private ICourseRepository _courseRepository;
         private GetAllCoursesBySearchCriteriaQueryHandler _handler;
         private SearchCriteria? _searchCriteria;

--- a/Test-Layer/ModuleTest/IntegrationTest/ModuleControllerIntegrationCreateModuleTest.cs
+++ b/Test-Layer/ModuleTest/IntegrationTest/ModuleControllerIntegrationCreateModuleTest.cs
@@ -1,9 +1,10 @@
 ﻿using API_Layer.Controllers;
 using Application_Layer.Commands.ModuleCommands.CreateModule;
-using Application_Layer.DTO_s.Module;
 using FakeItEasy;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
+using Shared_Layer.DTO_s.Module;
+
 
 namespace Test_Layer.ModuleTest.IntegrationTest
 {

--- a/Test-Layer/ModuleTest/IntegrationTest/ModuleControllerIntegrationUpdateModuleTest.cs
+++ b/Test-Layer/ModuleTest/IntegrationTest/ModuleControllerIntegrationUpdateModuleTest.cs
@@ -1,10 +1,10 @@
 ﻿using API_Layer.Controllers;
 using Application_Layer.Commands.ModuleCommands.UpdateModule;
-using Application_Layer.DTO_s.Module;
 using Domain_Layer.Models.Module;
 using FakeItEasy;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
+using Shared_Layer.DTO_s.Module;
 
 namespace Test_Layer.ModuleTest.IntegrationTest
 {

--- a/Test-Layer/ModuleTest/UnitTest/ModuleCommandTest/CreateModuleCommandHandlerTest.cs
+++ b/Test-Layer/ModuleTest/UnitTest/ModuleCommandTest/CreateModuleCommandHandlerTest.cs
@@ -1,9 +1,9 @@
 ﻿using Application_Layer.Commands.ModuleCommands.CreateModule;
-using Application_Layer.DTO_s.Module;
 using AutoMapper;
 using Domain_Layer.Models.Module;
 using FakeItEasy;
 using Infrastructure_Layer.Repositories.Module;
+using Shared_Layer.DTO_s.Module;
 
 namespace Test_Layer.ModuleTest.UnitTest.ModuleCommandTest
 {

--- a/Test-Layer/ModuleTest/UnitTest/ModuleCommandTest/UpdateModuleCommandHandlerTests.cs
+++ b/Test-Layer/ModuleTest/UnitTest/ModuleCommandTest/UpdateModuleCommandHandlerTests.cs
@@ -1,11 +1,11 @@
 ﻿using Application_Layer.Commands.ModuleCommands.UpdateModule;
-using Application_Layer.DTO_s.Module;
 using AutoMapper;
 using Domain_Layer.Models.Module;
 using FakeItEasy;
 using FluentAssertions;
 using Infrastructure_Layer.Repositories.Module;
 using Microsoft.AspNetCore.Mvc;
+using Shared_Layer.DTO_s.Module;
 
 
 namespace Test_Layer.ModuleTest.UnitTest.ModuleCommandTest

--- a/Test-Layer/UserTest/IntegrationTests/UserControllerIntegrationLoginTests.cs
+++ b/Test-Layer/UserTest/IntegrationTests/UserControllerIntegrationLoginTests.cs
@@ -1,11 +1,11 @@
 ﻿using Application_Layer.Commands.RegisterNewUser;
 using Application_Layer.Controllers;
-using Application_Layer.DTO_s;
 using Application_Layer.Queries.LoginUser;
 using Domain_Layer.Models.User;
 using FakeItEasy;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
+using Shared_Layer.DTO_s.User;
 
 namespace Test_Layer.UserTest.IntegrationTests
 {

--- a/Test-Layer/UserTest/IntegrationTests/UserControllerIntegrationRegisterTests.cs
+++ b/Test-Layer/UserTest/IntegrationTests/UserControllerIntegrationRegisterTests.cs
@@ -1,10 +1,10 @@
 ﻿using Application_Layer.Commands.RegisterNewUser;
 using Application_Layer.Controllers;
-using Application_Layer.DTO_s;
 using Domain_Layer.Models.User;
 using FakeItEasy;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
+using Shared_Layer.DTO_s.User;
 
 namespace Test_Layer.UserTest.IntegrationTests
 {

--- a/Test-Layer/UserTest/IntegrationTests/UserControllerIntegrationUpdateUserTest.cs
+++ b/Test-Layer/UserTest/IntegrationTests/UserControllerIntegrationUpdateUserTest.cs
@@ -1,12 +1,12 @@
 ﻿using System.Security.Claims;
 using Application_Layer.Commands.UpdateUser;
 using Application_Layer.Controllers;
-using Application_Layer.DTO_s;
 using Domain_Layer.Models.User;
 using FakeItEasy;
 using MediatR;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Shared_Layer.DTO_s.User;
 
 namespace Test_Layer.UserTest.IntegrationTests
 {

--- a/Test-Layer/UserTest/UnitTests/UserCommandTests/RegisterUserCommandHandlerTests.cs
+++ b/Test-Layer/UserTest/UnitTests/UserCommandTests/RegisterUserCommandHandlerTests.cs
@@ -1,10 +1,10 @@
 ﻿using Application_Layer.Commands.RegisterNewUser;
-using Application_Layer.DTO_s;
 using AutoFixture;
 using AutoMapper;
 using Domain_Layer.Models.User;
 using FakeItEasy;
 using Infrastructure_Layer.Repositories.User;
+using Shared_Layer.DTO_s.User;
 
 namespace Test_Layer.UserTest.UnitTests.UserCommandTests
 {

--- a/Test-Layer/UserTest/UnitTests/UserCommandTests/UpdateUserCommandHandlerTests.cs
+++ b/Test-Layer/UserTest/UnitTests/UserCommandTests/UpdateUserCommandHandlerTests.cs
@@ -1,10 +1,10 @@
 ﻿using Application_Layer.Commands.UpdateUser;
-using Application_Layer.DTO_s;
 using AutoFixture;
 using AutoMapper;
 using Domain_Layer.Models.User;
 using FakeItEasy;
 using Infrastructure_Layer.Repositories.User;
+using Shared_Layer.DTO_s.User;
 
 namespace Test_Layer.UserTest.UnitTests.UserCommandTests
 {

--- a/Test-Layer/UserTest/UnitTests/UserQueryTests/LoginUserQueryHandlerTests.cs
+++ b/Test-Layer/UserTest/UnitTests/UserQueryTests/LoginUserQueryHandlerTests.cs
@@ -1,10 +1,10 @@
-﻿using Application_Layer.DTO_s;
-using Application_Layer.Queries.LoginUser;
+﻿using Application_Layer.Queries.LoginUser;
 using Domain_Layer.Models.User;
 using FakeItEasy;
 using Infrastructure_Layer.Repositories.User;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
+using Shared_Layer.DTO_s.User;
 
 namespace Test_Layer.UserTest.UnitTests.UserQueryTests
 {


### PR DESCRIPTION
# Moving DTOs to Shared-Layer

## Description

I have decide to move away DTOs from Aplication-Layer to Shared-Layer becouse I hade dependency errors which are coused by some of Nuget packages inside Infrastructure or Aplication-Layer.

## Changes Made

DTO's moved, all namespaces are updated to the new DTO´s location

## Related Ticket or Issue

- Fixes #ISSUE_NUMBER <!-- Replace ISSUE_NUMBER with the actual number of the GitHub issue or ticket. -->
- Closes #PROJECT_NAME/ISSUE_NUMBER <!-- Replace PROJECT_NAME with the name of your GitHub project. -->

## Checklist

- [x] Code adheres to the coding conventions
- [x] Unit tests are added for new code
- [x] Existing unit tests are updated if needed
- [x] Code follows the principles of Clean Architecture
- [x] Code formatting complies with the `.editorconfig` file
- [x] Pull request template is filled out
